### PR TITLE
Detect the first run for different versions

### DIFF
--- a/fixture/test1.js
+++ b/fixture/test1.js
@@ -1,0 +1,7 @@
+'use strict';
+const Configstore = require('configstore');
+const firstRun = require('..');
+
+(new Configstore('first-run_first-run')).clear();
+// eslint-disable-next-line unicorn/no-process-exit
+process.exit(firstRun() ? 0 : 1);

--- a/fixture/test2.js
+++ b/fixture/test2.js
@@ -1,5 +1,5 @@
 'use strict';
-const firstRun = require('.');
+const firstRun = require('..');
 
 // eslint-disable-next-line unicorn/no-process-exit
 process.exit(firstRun() ? 1 : 0);

--- a/fixture/test3.js
+++ b/fixture/test3.js
@@ -1,6 +1,6 @@
 'use strict';
 const Configstore = require('configstore');
-const firstRun = require('.');
+const firstRun = require('..');
 
 (new Configstore('first-run_first-run')).clear();
 const shouldBeTrue = firstRun();

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,10 @@ declare namespace firstRun {
 		The name used to identify it. Default: `name` field in your package.json
 		*/
 		readonly name?: string;
+		/**
+		The version used to identify it. Default: if `name` is not set, `version` field in your package.json, otherwise `undefined`.
+		*/
+		readonly version?: string;
 	}
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare namespace firstRun {
 		readonly version?: undefined | string;
 
 		/**
-		When `name` is detected from `package.json`, version will be also detected and used if this field was set to `true`. Default: `false`
+		If set to `true` and `name` detected from `package.json`, `version` will be also detected. Default: `false`
 		*/
 		readonly detectVersion?: boolean;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,9 +5,14 @@ declare namespace firstRun {
 		*/
 		readonly name?: string;
 		/**
-		The version used to identify it. Default: if `name` is not set, `version` field in your package.json, otherwise `undefined`.
+		The version used to identify it. Default: `undefined`
 		*/
 		readonly version?: undefined | string;
+
+		/**
+		When `name` is detected from `package.json`, version will be also detected and used if this field was set to `true`. Default: `false`
+		*/
+		readonly detectVersion?: boolean;
 	}
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,13 +7,13 @@ declare namespace firstRun {
 		/**
 		The version used to identify it. Default: if `name` is not set, `version` field in your package.json, otherwise `undefined`.
 		*/
-		readonly version?: string;
+		readonly version?: undefined | string;
 	}
 }
 
 declare const firstRun: {
 	/**
-	Check if it's the first time the process is run.
+	Returns true the first time function is executed on machine for specified `name` and `version` pair, false afterwards.
 
 	@example
 	```
@@ -31,7 +31,7 @@ declare const firstRun: {
 	(options?: firstRun.Options): boolean;
 
 	/**
-	Clear the state.
+	Clear the saved state for specified `name` and `version` pair. Next call of `firstRun` for this pair will return true.
 	*/
 	clear(options?: firstRun.Options): void;
 };

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const Configstore = require('configstore');
 const readPkgUp = require('read-pkg-up');
 
 const getConfigStoreAndKey = (options = {}) => {
-	let {name, version} = options;
+	let {name, version, detectVersion} = options;
 
 	if (!name) {
 		delete require.cache[__filename];
@@ -15,7 +15,7 @@ const getConfigStoreAndKey = (options = {}) => {
 			throw new Error('Couldn\'t infer the package name. Please specify it in the options.');
 		}
 
-		if (!version) {
+		if (detectVersion) {
 			version = pkg.version;
 		}
 	}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,3 +6,4 @@ expectType<boolean>(firstRun({name: 'foo'}));
 
 firstRun.clear();
 firstRun.clear({name: 'foo'});
+firstRun.clear({name: 'foo', version:'1.2.3'});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && node test.js && node test2.js && node test3.js && tsd"
+		"test": "xo && nyc ava && tsd"
 	},
 	"files": [
 		"index.js",
@@ -29,6 +29,7 @@
 		"start"
 	],
 	"dependencies": {
+		"ava": "^2.1.0",
 		"configstore": "^4.0.0",
 		"read-pkg-up": "^5.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -29,11 +29,12 @@
 		"start"
 	],
 	"dependencies": {
-		"ava": "^2.1.0",
 		"configstore": "^4.0.0",
 		"read-pkg-up": "^5.0.0"
 	},
 	"devDependencies": {
+		"ava": "^2.1.0",
+		"nyc": "^14.1.1",
 		"tsd": "^0.7.2",
 		"xo": "^0.24.0"
 	}

--- a/readme.md
+++ b/readme.md
@@ -76,9 +76,16 @@ The name used to identify it.
 ##### version
 
 Type: `string`<br>
-Default: if `name` is not set, `version` field in your package.json, otherwise `undefined`.
+Default: `undefined`.
 
 The version used to identify it.
+
+##### detectVersion
+
+Type: `boolean`<br>
+Default: `false`.
+
+When `name` is detected from `package.json`, version will be also detected and used if this field was set to `true`.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -14,23 +14,24 @@ $ npm install first-run
 
 ## Usage
 
-Simple use case, inside package(`name` and `version` will be take from `package.json`):
+### Without version
+Simple use case, inside package(`name` will be taken from `package.json`):
 
 ```js
 // x.js
 const firstRun = require('first-run');
 
-console.log(firstRun()); // name and version will be inferred
+console.log(firstRun()); // name will be inferred
 ```
 
 ```js
 // clear.js
 const firstRun = require('first-run');
 
-firstRun.clear(); // name and version will be inferred
+firstRun.clear(); // name will be inferred
 ```
 
-```
+```sh
 $ node x.js
 true
 $ node x.js
@@ -42,9 +43,35 @@ $ node x.js
 false
 ```
 
-Then, after package version changes:
+### With version
 
+Simple use case, inside package(`name` and `version` will be taken from `package.json`):
+
+```js
+// x.js
+const firstRun = require('first-run');
+
+console.log(firstRun({detectVersion: true})); // name and version will be inferred
 ```
+
+```js
+// clear.js
+const firstRun = require('first-run');
+
+firstRun.clear({detectVersion: true}); // name and version will be inferred
+```
+
+```sh
+$ node x.js
+true
+$ node x.js
+false
+$ node clear.js
+$ node x.js
+true
+$ node x.js
+false
+# version in package.json changes
 $ node x.js
 true
 $ node x.js

--- a/readme.md
+++ b/readme.md
@@ -112,7 +112,7 @@ The version used to identify it.
 Type: `boolean`<br>
 Default: `false`.
 
-When `name` is detected from `package.json`, version will be also detected and used if this field was set to `true`.
+If set to `true` and `name` detected from `package.json`, `version` will be also detected.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,12 @@ Default: `name` field in your package.json
 
 The name used to identify it.
 
+##### version
+
+Type: `string`<br>
+Default: if `name` is not set, `version` field in your package.json, otherwise `undefined`.
+
+The version used to identify it.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -14,12 +14,35 @@ $ npm install first-run
 
 ## Usage
 
+Simple use case, inside package(`name` and `version` will be take from `package.json`):
+
 ```js
 // x.js
 const firstRun = require('first-run');
 
-console.log(firstRun());
+console.log(firstRun()); // name and version will be inferred
 ```
+
+```js
+// clear.js
+const firstRun = require('first-run');
+
+firstRun.clear(); // name and version will be inferred
+```
+
+```
+$ node x.js
+true
+$ node x.js
+false
+$ node clear.js
+$ node x.js
+true
+$ node x.js
+false
+```
+
+Then, after package version changes:
 
 ```
 $ node x.js
@@ -33,9 +56,11 @@ false
 
 ### firstRun([options])
 
+Returns true the first time function is executed on machine for specified `name` and `version` pair, false afterwards.
+
 ### firstRun.clear([options])
 
-Clear the state.
+Clear the saved state for specified `name` and `version` pair. Next call of `firstRun` for this pair will return true.
 
 #### options
 

--- a/test.js
+++ b/test.js
@@ -20,6 +20,12 @@ test.serial('main', t => {
 	t.false(firstRun());
 });
 
+test.serial('detected version', t => {
+	new Configstore('first-run_first-run').clear();
+	t.true(firstRun({detectVersion: true}));
+	t.false(firstRun({detectVersion: true}));
+});
+
 test.serial('clear', t => {
 	firstRun();
 	t.false(firstRun());

--- a/test.js
+++ b/test.js
@@ -1,7 +1,62 @@
-'use strict';
+const {exec} = require('child_process');
+
+const test = require('ava');
 const Configstore = require('configstore');
 const firstRun = require('.');
 
-(new Configstore('first-run_first-run')).clear();
-// eslint-disable-next-line unicorn/no-process-exit
-process.exit(firstRun() ? 0 : 1);
+const execAndGetCode = command => new Promise(resolve => {
+	exec(command, error => {
+		if (error === null) {
+			resolve(0);
+		} else {
+			resolve(error.code);
+		}
+	});
+});
+
+test.serial('main', t => {
+	new Configstore('first-run_first-run').clear();
+	t.true(firstRun());
+	t.false(firstRun());
+});
+
+test.serial('clear', t => {
+	firstRun();
+	t.false(firstRun());
+	firstRun.clear();
+	t.true(firstRun());
+});
+
+test.serial('separate processes', async t => {
+	t.is(await execAndGetCode('node fixture/test1.js'), 0);
+	t.is(await execAndGetCode('node fixture/test2.js'), 0);
+	t.is(await execAndGetCode('node fixture/test3.js'), 0);
+});
+
+test.serial('version', t => {
+	new Configstore('first-run_first-run-test').clear();
+
+	t.true(firstRun({name: 'first-run-test', version: '1.0.0'}));
+	t.false(firstRun({name: 'first-run-test', version: '1.0.0'}));
+	t.true(firstRun({name: 'first-run-test', version: '2.0.0'}));
+	t.false(firstRun({name: 'first-run-test', version: '2.0.0'}));
+});
+
+test.serial('no-version to version ', t => {
+	new Configstore('first-run_first-run-test').clear();
+
+	t.true(firstRun({name: 'first-run-test'}));
+	t.false(firstRun({name: 'first-run-test'}));
+	t.true(firstRun({name: 'first-run-test', version: '1.0.0'}));
+	t.false(firstRun({name: 'first-run-test', version: '1.0.0'}));
+});
+
+test.serial('version to no-version', t => {
+	new Configstore('first-run_first-run-test').clear();
+
+	t.true(firstRun({name: 'first-run-test', version: '1.0.0'}));
+	t.false(firstRun({name: 'first-run-test', version: '1.0.0'}));
+	t.false(firstRun({name: 'first-run-test'}));
+	firstRun.clear({name: 'first-run-test'});
+	t.true(firstRun({name: 'first-run-test'}));
+});


### PR DESCRIPTION
Start using versions, fixes #1.

If only name is set, works like it did before. Config record is backward compatible with previous versions.
Essentially, it will work out of the box with versioning without changes of code for most users.

Currently, full versions are compared, but if we want to have partial comparison, I need proposals on flexibility we want.